### PR TITLE
add default start priority to hivemq-extension.xml

### DIFF
--- a/src/main/resources/hivemq-extension.xml
+++ b/src/main/resources/hivemq-extension.xml
@@ -19,5 +19,6 @@
     <name>${extension.name}</name>
     <version>${version}</version>
     <priority>1000</priority>
+    <start-priority>1000</start-priority>
     <author>dc-square GmbH</author>
 </hivemq-extension>


### PR DESCRIPTION
This will allow users of this extension to easily be able to use `sed` or any other text manipulation tool to change the `start-priorty`.