### PR TITLE
#15 Add optional labels and suffix to prometheus metrics.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,14 @@ The extension can be configured with the `prometheusConfiguration.properties` fi
 |/metrics
 |The path for the service which gets called by Prometheus. It must start with a slash.
 
+|labels
+| -
+|An optional list of labels, that are attached to metrics, separated by semicolon. (host_ip=0.0.0.0;cluster=my-cluster)
+
+|suffix
+| -
+|An optional suffix that is appended to each metric name. (metric_name_suffix)
+
 |===
 
 == First Steps

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.eclipse.jetty:jetty-servlet:${property("jetty.version")}")
     implementation("org.eclipse.jetty:jetty-util:${property("jetty.version")}")
     implementation("org.aeonbits.owner:owner:${property("owner.version")}")
+    implementation("org.apache.commons:commons-lang3:${property("commons-lang3.version")}")
 
     testImplementation("junit:junit:${property("junit.version")}")
     testImplementation("org.mockito:mockito-all:${property("mockito.version")}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ hivemq-extension-sdk.version=4.0.0
 prometheus-simpleclient.version=0.9.0
 jetty.version=9.4.27.v20200227
 owner.version=1.0.10
+commons-lang3.version=3.11
 #
 # test dependencies
 #

--- a/src/hivemq-extension/prometheusConfiguration.properties
+++ b/src/hivemq-extension/prometheusConfiguration.properties
@@ -25,6 +25,11 @@ port=9399
 # For example 127.0.0.1:9399/metrics
 metric_path=/metrics
 
+# Optional labels for prometheus that are attached to each metric
+# labels=host=--NODE-NAME--
+
+# Optional suffix for prometheus that is appended to each metric name
+# suffix=cluster01
 
 
 

--- a/src/main/java/com/hivemq/extensions/prometheus/configuration/PrometheusExtensionConfiguration.java
+++ b/src/main/java/com/hivemq/extensions/prometheus/configuration/PrometheusExtensionConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.hivemq.extensions.prometheus.configuration;
 
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import org.aeonbits.owner.Config;
 
 import static org.aeonbits.owner.Config.DisableableFeature.PARAMETER_FORMATTING;
@@ -27,7 +28,8 @@ public interface PrometheusExtensionConfiguration extends Config {
     String METRIC_PATH_KEY = "metric_path";
     String IP_KEY = "ip";
     String PORT_KEY = "port";
-
+    String LABELS = "labels";
+    String SUFFIX = "suffix";
 
     @Key(PORT_KEY)
     int port();
@@ -37,4 +39,10 @@ public interface PrometheusExtensionConfiguration extends Config {
 
     @Key(METRIC_PATH_KEY)
     String metricPath();
+
+    @Key(LABELS)
+    @Nullable String labels();
+
+    @Key(SUFFIX)
+    @Nullable String suffix();
 }

--- a/src/main/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilder.java
+++ b/src/main/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilder.java
@@ -47,7 +47,7 @@ public class PrometheusSampleBuilder implements SampleBuilder {
 
 
     @Override
-    public Collector.MetricFamilySamples.Sample createSample(
+    public @NotNull Collector.MetricFamilySamples.Sample createSample(
             final @NotNull String dropwizardName,
             final @Nullable String nameSuffix,
             final @Nullable List<String> additionalLabelNames,
@@ -64,7 +64,7 @@ public class PrometheusSampleBuilder implements SampleBuilder {
                 value);
     }
 
-    private List<String> combineLists(final @Nullable List<String> additionalList, final @NotNull List<String> configList) {
+    private @NotNull List<String> combineLists(final @Nullable List<String> additionalList, final @NotNull List<String> configList) {
         if (additionalList != null && additionalList.size() > 0) {
             final List<String> composite = new ArrayList<>();
             composite.addAll(additionalList);

--- a/src/main/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilder.java
+++ b/src/main/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hivemq.extensions.prometheus.export;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extensions.prometheus.configuration.PrometheusExtensionConfiguration;
+import io.prometheus.client.Collector;
+import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrometheusSampleBuilder implements SampleBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(PrometheusSampleBuilder.class);
+
+    private String suffix = "";
+    private final List<String> labelNames = new ArrayList<>();
+    private final List<String> labelValues= new ArrayList<>();
+
+    public PrometheusSampleBuilder(@NotNull final PrometheusExtensionConfiguration extensionConfiguration) {
+        setSuffix(extensionConfiguration.suffix());
+        setLabels(extensionConfiguration.labels());
+    }
+
+    @Override
+    public Collector.MetricFamilySamples.Sample createSample(
+            final String dropwizardName,
+            final String nameSuffix,
+            final List<String> additionalLabelNames,
+            final List<String> additionalLabelValues,
+            final double value) {
+        return new Collector.MetricFamilySamples.Sample(
+                Collector.sanitizeMetricName(dropwizardName + suffix), labelNames, labelValues, value
+        );
+    }
+
+    private void setSuffix(final String confSuffix) {
+        if (confSuffix != null && confSuffix.length() > 0) {
+            this.suffix = "." + confSuffix;
+        }
+    }
+
+    private void setLabels(final String labels) {
+        if (labels != null && labels.length() > 2) {
+
+            final String[] splitLabels = StringUtils.splitPreserveAllTokens(labels, ";");
+
+            for (final String label : splitLabels) {
+                final String[] labelPair = StringUtils.split(label, "=");
+                if (labelPair.length != 2 || labelPair[0].length() < 1 || labelPair[1].length() < 1) {
+                    log.info("Skipping invalid label '{}' for Prometheus in labels '{}'.", label, labels);
+                } else {
+                    labelNames.add(StringUtils.trim(labelPair[0]));
+                    labelValues.add(StringUtils.trim(labelPair[1]));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hivemq/extensions/prometheus/export/PrometheusServer.java
+++ b/src/main/java/com/hivemq/extensions/prometheus/export/PrometheusServer.java
@@ -75,7 +75,7 @@ public class PrometheusServer {
 
     public void start() {
 
-        dropwizardExports = new DropwizardExports(metricRegistry);
+        dropwizardExports = new DropwizardExports(metricRegistry, new PrometheusSampleBuilder(configuration));
 
         CollectorRegistry.defaultRegistry.register(dropwizardExports);
         final ServletContextHandler context = new ServletContextHandler();

--- a/src/test/java/com/hivemq/extensions/prometheus/configuration/ConfigurationReaderTest.java
+++ b/src/test/java/com/hivemq/extensions/prometheus/configuration/ConfigurationReaderTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -162,5 +163,17 @@ public class ConfigurationReaderTest {
         }
     }
 
+    @Test
+    public void test_successfully_read_labels_in_config() throws Exception {
+        configurationReader = new ConfigurationReader(extensionInformation);
+        when(extensionInformation.getExtensionHomeFolder()).thenReturn(temporaryFolder.getRoot());
 
+        final FileWriter out = new FileWriter(temporaryFolder.newFile(ConfigurationReader.CONFIG_PATH));
+
+        out.write("metric_path=/metrics\nip=127.0.0.1\nport=1234\nhttps.enabled=true\nlabels=host=some");
+        out.flush();
+        out.close();
+        final PrometheusExtensionConfiguration conf = configurationReader.readConfiguration();
+        assertEquals("Failed to read labels", "host=some", conf.labels());
+    }
 }

--- a/src/test/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilderTest.java
+++ b/src/test/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilderTest.java
@@ -16,8 +16,10 @@
 
 package com.hivemq.extensions.prometheus.export;
 
+import com.codahale.metrics.MetricRegistry;
 import com.hivemq.extensions.prometheus.configuration.PrometheusExtensionConfiguration;
 import io.prometheus.client.Collector;
+import io.prometheus.client.dropwizard.DropwizardExports;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,8 +27,10 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 public class PrometheusSampleBuilderTest {
 
@@ -40,7 +44,7 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_add_one_label() {
         Mockito.when(config.labels()).thenReturn("host_ip=1.2.3.4");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("name incorrect", Collections.singletonList("host_ip"), sample.labelNames);
         assertEquals("value incorrect", Collections.singletonList("1.2.3.4"), sample.labelValues);
     }
@@ -48,7 +52,7 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_add_two_labels() {
         Mockito.when(config.labels()).thenReturn("host_ip=1.2.3.4;scp=some.longer.name");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("names incorrect", Arrays.asList("host_ip", "scp"), sample.labelNames);
         assertEquals("values incorrect", Arrays.asList("1.2.3.4", "some.longer.name"), sample.labelValues);
     }
@@ -56,7 +60,7 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_labels_with_trailing_semicolon() {
         Mockito.when(config.labels()).thenReturn("host_ip=1.2.3.4;");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("name incorrect", Collections.singletonList("host_ip"), sample.labelNames);
         assertEquals("value incorrect", Collections.singletonList("1.2.3.4"), sample.labelValues);
     }
@@ -64,7 +68,7 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_invalid_labels() {
         Mockito.when(config.labels()).thenReturn("host_ip=;");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("name should be empty", Collections.EMPTY_LIST, sample.labelNames);
         assertEquals("value should be empty", Collections.EMPTY_LIST, sample.labelValues);
     }
@@ -72,7 +76,7 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_empty_labels() {
         Mockito.when(config.labels()).thenReturn("");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("name should be empty", Collections.EMPTY_LIST, sample.labelNames);
         assertEquals("value should be empty", Collections.EMPTY_LIST, sample.labelValues);
     }
@@ -80,7 +84,7 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_chinese_labels() {
         Mockito.when(config.labels()).thenReturn("的=不");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("name incorrect", Collections.singletonList("的"), sample.labelNames);
         assertEquals("value incorrect", Collections.singletonList("不"), sample.labelValues);
     }
@@ -88,54 +92,109 @@ public class PrometheusSampleBuilderTest {
     @Test
     public void test_labels_with_leading_whitespace() {
         Mockito.when(config.labels()).thenReturn("            host_ip=1.2.3.4");
-        final Collector.MetricFamilySamples.Sample sample = getSample();
+        final Collector.MetricFamilySamples.Sample sample = getSampleForName("test");
         assertEquals("name incorrect", Collections.singletonList("host_ip"), sample.labelNames);
         assertEquals("value incorrect", Collections.singletonList("1.2.3.4"), sample.labelValues);
     }
 
     @Test
     public void test_suffix_for_name() {
-        final String metricName = "test.some.metric.name";
+        final String metricName = "test.name";
         final String suffix = "suffix";
         Mockito.when(config.suffix()).thenReturn(suffix);
-        assertEquals("Metric name doesn't match",
-                Collector.sanitizeMetricName(metricName + "_" + suffix), getSampleForName(metricName).name);
+        assertEquals("Metric name incorrect", "test_name_suffix", getSampleForName(metricName).name);
     }
 
     @Test
     public void test_random_suffix_for_name() {
-        final String metricName = "test.some.metric.name";
-        final String suffix = RandomStringUtils.random(255, true, true);
+        final String metricName = "test.name";
+        final String suffix = RandomStringUtils.random(55, true, true);
         Mockito.when(config.suffix()).thenReturn(suffix);
-        assertEquals("Metric name doesn't match",
-                Collector.sanitizeMetricName(metricName + "_" + suffix), getSampleForName(metricName).name);
+        assertEquals("Metric name incorrect", "test_name_" + suffix, getSampleForName(metricName).name);
     }
 
     @Test
     public void test_empty_suffix() {
-        final String metricName = "test.some.metric.name";
+        final String metricName = "test.name";
         Mockito.when(config.suffix()).thenReturn("");
-        assertEquals("Metric name doesn't match",
-                Collector.sanitizeMetricName(metricName), getSampleForName(metricName).name);
+        assertEquals("Metric name incorrect", "test_name", getSampleForName(metricName).name);
     }
 
     @Test
-    public void test_with_period() {
-        final String metricName = "test.some.metric.name";
+    public void test_suffix_with_period() {
+        final String metricName = "test.name";
         final String suffix = ".test";
         Mockito.when(config.suffix()).thenReturn(suffix);
-        assertEquals("Metric name doesn't match",
-                Collector.sanitizeMetricName(metricName + "_" + suffix ), getSampleForName(metricName).name);
+        assertEquals("Metric name incorrect", "test_name__test", getSampleForName(metricName).name);
     }
 
-    private Collector.MetricFamilySamples.Sample getSample() {
-        final String metricName = "test";
-        return getSampleForName(metricName);
+    @Test
+    public void test_adding_suffix_to_meter() {
+        final String suffix = "cluster1";
+        when(config.suffix()).thenReturn(suffix);
+
+        final MetricRegistry registry = new MetricRegistry();
+        registry.meter("testing.meter");
+
+        final String name = new DropwizardExports(registry, new PrometheusSampleBuilder(config)).collect().get(0).name;
+        assertEquals("metric name incorrect", "testing_meter_total_" + suffix, name);
+    }
+
+    @Test
+    public void test_metrics_compare_histogram() {
+        final MetricRegistry registry = new MetricRegistry();
+        registry.histogram("testing.histogram");
+        compareQuantileSamples(registry);
+    }
+
+    @Test
+    public void test_metrics_compare_timer() {
+        final MetricRegistry registry = new MetricRegistry();
+        registry.timer("testing.timer");
+        compareQuantileSamples(registry);
+    }
+
+    @Test
+    public void test_quantile_metrics_with_labels() {
+        when(config.labels()).thenReturn("hostname=test.invalid.domain");
+
+        final MetricRegistry registry = new MetricRegistry();
+        registry.histogram("testing.histogram");
+
+        final List<Collector.MetricFamilySamples.Sample> labeledSamples =
+                new DropwizardExports(registry, new PrometheusSampleBuilder(config)).collect().get(0).samples;
+
+        assertEquals("Number of labels incorrect", 2, labeledSamples.get(0).labelNames.size());
+
+        for (final Collector.MetricFamilySamples.Sample sample :  labeledSamples) {
+            if (sample.name.endsWith("_count")) {
+                //quantile_count sample
+                assertEquals("names not matching", List.of("hostname"), sample.labelNames);
+            } else {
+                assertEquals("sample not matching", List.of("quantile", "hostname"), sample.labelNames);
+            }
+        }
     }
 
     private Collector.MetricFamilySamples.Sample getSampleForName(final String metricName) {
         final PrometheusSampleBuilder builder = new PrometheusSampleBuilder(config);
         return builder.createSample(metricName, null,
                 null, null, 1.0);
+    }
+
+    private void compareQuantileSamples(final MetricRegistry registry) {
+        when(config.labels()).thenReturn("");
+
+        final List<Collector.MetricFamilySamples.Sample> defaultSamples =
+                new DropwizardExports(registry).collect().get(0).samples;
+        final List<Collector.MetricFamilySamples.Sample> labeledSamples =
+                new DropwizardExports(registry, new PrometheusSampleBuilder(config)).collect().get(0).samples;
+
+        assertEquals("Number of samples incorrect", defaultSamples.size(), labeledSamples.size());
+        assertEquals("Number of labels incorrect", defaultSamples.get(0).labelNames.size(), labeledSamples.get(0).labelNames.size());
+
+        for (int i = 0; i < defaultSamples.size(); i++) {
+            assertEquals("sample not matching", defaultSamples.get(i), labeledSamples.get(i));
+        }
     }
 }

--- a/src/test/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilderTest.java
+++ b/src/test/java/com/hivemq/extensions/prometheus/export/PrometheusSampleBuilderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hivemq.extensions.prometheus.export;
+
+import com.hivemq.extensions.prometheus.configuration.PrometheusExtensionConfiguration;
+import io.prometheus.client.Collector;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrometheusSampleBuilderTest {
+
+    private PrometheusExtensionConfiguration config;
+
+    @Before
+    public void setup() {
+        config = Mockito.mock(PrometheusExtensionConfiguration.class);
+    }
+
+    @Test
+    public void test_add_one_label() {
+        Mockito.when(config.labels()).thenReturn("host_ip=1.2.3.4");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("name incorrect", Collections.singletonList("host_ip"), sample.labelNames);
+        assertEquals("value incorrect", Collections.singletonList("1.2.3.4"), sample.labelValues);
+    }
+
+    @Test
+    public void test_add_two_labels() {
+        Mockito.when(config.labels()).thenReturn("host_ip=1.2.3.4;scp=some.longer.name");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("names incorrect", Arrays.asList("host_ip", "scp"), sample.labelNames);
+        assertEquals("values incorrect", Arrays.asList("1.2.3.4", "some.longer.name"), sample.labelValues);
+    }
+
+    @Test
+    public void test_labels_with_trailing_semicolon() {
+        Mockito.when(config.labels()).thenReturn("host_ip=1.2.3.4;");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("name incorrect", Collections.singletonList("host_ip"), sample.labelNames);
+        assertEquals("value incorrect", Collections.singletonList("1.2.3.4"), sample.labelValues);
+    }
+
+    @Test
+    public void test_invalid_labels() {
+        Mockito.when(config.labels()).thenReturn("host_ip=;");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("name should be empty", Collections.EMPTY_LIST, sample.labelNames);
+        assertEquals("value should be empty", Collections.EMPTY_LIST, sample.labelValues);
+    }
+
+    @Test
+    public void test_empty_labels() {
+        Mockito.when(config.labels()).thenReturn("");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("name should be empty", Collections.EMPTY_LIST, sample.labelNames);
+        assertEquals("value should be empty", Collections.EMPTY_LIST, sample.labelValues);
+    }
+
+    @Test
+    public void test_chinese_labels() {
+        Mockito.when(config.labels()).thenReturn("的=不");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("name incorrect", Collections.singletonList("的"), sample.labelNames);
+        assertEquals("value incorrect", Collections.singletonList("不"), sample.labelValues);
+    }
+
+    @Test
+    public void test_labels_with_leading_whitespace() {
+        Mockito.when(config.labels()).thenReturn("            host_ip=1.2.3.4");
+        final Collector.MetricFamilySamples.Sample sample = getSample();
+        assertEquals("name incorrect", Collections.singletonList("host_ip"), sample.labelNames);
+        assertEquals("value incorrect", Collections.singletonList("1.2.3.4"), sample.labelValues);
+    }
+
+    @Test
+    public void test_suffix_for_name() {
+        final String metricName = "test.some.metric.name";
+        final String suffix = "suffix";
+        Mockito.when(config.suffix()).thenReturn(suffix);
+        assertEquals("Metric name doesn't match",
+                Collector.sanitizeMetricName(metricName + "_" + suffix), getSampleForName(metricName).name);
+    }
+
+    @Test
+    public void test_random_suffix_for_name() {
+        final String metricName = "test.some.metric.name";
+        final String suffix = RandomStringUtils.random(255, true, true);
+        Mockito.when(config.suffix()).thenReturn(suffix);
+        assertEquals("Metric name doesn't match",
+                Collector.sanitizeMetricName(metricName + "_" + suffix), getSampleForName(metricName).name);
+    }
+
+    @Test
+    public void test_empty_suffix() {
+        final String metricName = "test.some.metric.name";
+        Mockito.when(config.suffix()).thenReturn("");
+        assertEquals("Metric name doesn't match",
+                Collector.sanitizeMetricName(metricName), getSampleForName(metricName).name);
+    }
+
+    @Test
+    public void test_with_period() {
+        final String metricName = "test.some.metric.name";
+        final String suffix = ".test";
+        Mockito.when(config.suffix()).thenReturn(suffix);
+        assertEquals("Metric name doesn't match",
+                Collector.sanitizeMetricName(metricName + "_" + suffix ), getSampleForName(metricName).name);
+    }
+
+    private Collector.MetricFamilySamples.Sample getSample() {
+        final String metricName = "test";
+        return getSampleForName(metricName);
+    }
+
+    private Collector.MetricFamilySamples.Sample getSampleForName(final String metricName) {
+        final PrometheusSampleBuilder builder = new PrometheusSampleBuilder(config);
+        return builder.createSample(metricName, null,
+                null, null, 1.0);
+    }
+}


### PR DESCRIPTION
Motivation

Add optional support for labels and metric name suffix to prometheus metrics from configuration. Can be used to add hostname or IP address to metrics for example. Labels can be used in PromQL queries.

Changes

implement io.prometheus.client.dropwizard.samplebuilder.SampleBuilder to support labels
add optional labels to configuration
add optional suffix to configuration

Example metric:
com_hivemq_jvm_threads_runnable_count_cluster01{host="rivendell",host_ip="127.0.0.1",} 19.0
