### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/.github/workflows/releaseExtension.yml
+++ b/.github/workflows/releaseExtension.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Check for new issues
         uses: hivemq/hivemq-snyk-composite-action@1c18f39e10e7b1d35fa121b91b99c0445b7a4a56 # v2

--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/.github/workflows/snyk-release.yml
+++ b/.github/workflows/snyk-release.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ hivemqExtension {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,11 +79,28 @@ oci {
     }
 }
 
+// see https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
+val mockitoAgent = configurations.create("mockitoAgent") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+dependencies {
+    mockitoAgent(libs.mockito) { isTransitive = false }
+}
+class MockitoAgentArgumentProvider(@get:Classpath val agentJar: FileCollection) : CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> = listOf("-javaagent:${agentJar.singleFile}")
+}
+
 @Suppress("UnstableApiUsage")
 testing {
     suites {
         withType<JvmTestSuite> {
             useJUnitJupiter(libs.versions.junit.jupiter)
+            targets.configureEach {
+                testTask {
+                    jvmArgumentProviders.add(MockitoAgentArgumentProvider(mockitoAgent))
+                }
+            }
         }
         "test"(JvmTestSuite::class) {
             dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,8 @@ testing {
             targets.configureEach {
                 testTask {
                     jvmArgumentProviders.add(MockitoAgentArgumentProvider(mockitoAgent))
+                    // see https://netty.io/wiki/java-24-and-sun.misc.unsafe.html
+                    jvmArgs("--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow")
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,12 @@ tasks.compileJava {
     }
 }
 
+tasks.named<JavaCompile>("compileIntegrationTestJava") {
+    // The integration tests bundle a HiveMQ extension that is loaded inside the HiveMQ container (Java 21).
+    // Compile to Java 21 bytecode so the container can load it, independent of the Java 25 build toolchain.
+    options.release.set(21)
+}
+
 dependencies {
     compileOnly(libs.jetbrains.annotations)
     implementation(libs.prometheus.simpleClient)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Upgrade the build toolchain to Java 25. Compile target stays at Java 11.

Part of INT-8.